### PR TITLE
Fix on bower dependencies in order to include the gpt-ad directly wit…

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,15 @@ googletag.cmd.push(function() {
 </script>
 ```
 
-3. Import and use the gpt-ad element inside any Web Component:
+3. Add the component in your polymer project:
+
+```html
+bower install --save googleads/gpt-ad
+
+```
+
+
+4. Import and use the gpt-ad element inside any Web Component:
 
 ```html
 <link rel="import" href="gpt-ad.html">

--- a/gpt-ad.html
+++ b/gpt-ad.html
@@ -9,8 +9,8 @@ or implied. See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <!-- Load the Polymer.Element base class -->
-<link rel="import" href="bower_components/polymer/polymer-element.html">
-<link rel="import" href="bower_components/polymer/lib/utils/render-status.html">
+<link rel="import" href="/bower_components/polymer/polymer-element.html">
+<link rel="import" href="/bower_components/polymer/lib/utils/render-status.html">
 <dom-module id="gpt-ad">
     <template>
         <style>


### PR DESCRIPTION
Hi guys! Today I tried to use gpt-ad component in my polymer project, but on polymer build I found:
"Promise rejection: Error: ENOENT: no such file or directory, open '/bower_components/google-gpt-ad/bower_components/polymer/polymer-element.html'".
With this patch my code worked just fine. I hope you could find it useful too.